### PR TITLE
Raise RTSLibNotInCFS when a storage object is not found in lookup mode

### DIFF
--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -26,7 +26,7 @@ import resource
 from six.moves import range
 
 from .node import CFSNode
-from .utils import fread, fwrite, RTSLibError, generate_wwn
+from .utils import fread, fwrite, generate_wwn, RTSLibError, RTSLibNotInCFS
 from .utils import convert_scsi_path_to_hctl, convert_scsi_hctl_to_path
 from .utils import is_dev_in_use, get_blockdev_type
 from .utils import get_size_for_blk_dev, get_size_for_disk_name
@@ -896,8 +896,8 @@ class _Backstore(CFSNode):
                               (self._plugin, name))
         elif self._index == None:
             if mode == 'lookup':
-                raise RTSLibError("Storage object %s/%s not found" %
-                                  (self._plugin, name))
+                raise RTSLibNotInCFS("Storage object %s/%s not found" %
+                                     (self._plugin, name))
             else:
                 # Allocate new index value
                 indexes = set(bs_cache.values())


### PR DESCRIPTION
The purpose of this patch is to restore the pre v2.1.fb44 behaviour
when a storage object in not found in lookup mode. Prior to v2.1.fb44,
the RTSLibNotInCFS exception was raised. Since v2.1.fb44, a more
generic RTSLibError is raised instead.

This patch fixes issue #57.

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>