### PR TITLE
Port to Python 3

### DIFF
--- a/rtslib/__init__.py
+++ b/rtslib/__init__.py
@@ -21,17 +21,17 @@ if __name__ == "rtslib":
     warn("'rtslib' package name for rtslib-fb is deprecated, please"
          + " instead import 'rtslib_fb'", UserWarning, stacklevel=2)
 
-from root import RTSRoot
-from utils import RTSLibError, RTSLibBrokenLink, RTSLibNotInCFS
+from .root import RTSRoot
+from .utils import RTSLibError, RTSLibBrokenLink, RTSLibNotInCFS
 
-from target import LUN, MappedLUN
-from target import NodeACL, NetworkPortal, TPG, Target
-from target import NodeACLGroup, MappedLUNGroup
-from fabric import FabricModule
+from .target import LUN, MappedLUN
+from .target import NodeACL, NetworkPortal, TPG, Target
+from .target import NodeACLGroup, MappedLUNGroup
+from .fabric import FabricModule
 
-from tcm import FileIOStorageObject, BlockStorageObject
-from tcm import PSCSIStorageObject, RDMCPStorageObject, UserBackedStorageObject
-from tcm import StorageObjectFactory
+from .tcm import FileIOStorageObject, BlockStorageObject
+from .tcm import PSCSIStorageObject, RDMCPStorageObject, UserBackedStorageObject
+from .tcm import StorageObjectFactory
 
 __version__ = 'GIT_VERSION'
 __author__ = "Jerome Martin <jxm@risingtidesystems.com>"

--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -107,15 +107,16 @@ Example: self._path = "%s/%s" % (self.configfs_dir, "my_cfs_dir")
 
 '''
 
-import os
-from glob import iglob as glob
-
-from node import CFSNode
-from utils import fread, fwrite, generate_wwn, normalize_wwn, colonize
-from utils import RTSLibError, modprobe, ignored
-from target import Target
-from utils import _get_auth_attr, _set_auth_attr
 from functools import partial
+from glob import iglob as glob
+import os
+import six
+
+from .node import CFSNode
+from .utils import fread, fwrite, generate_wwn, normalize_wwn, colonize
+from .utils import RTSLibError, modprobe, ignored
+from .target import Target
+from .utils import _get_auth_attr, _set_auth_attr
 
 version_attributes = {"lio_version", "version"}
 discovery_auth_attributes = {"discovery_auth"}
@@ -297,7 +298,7 @@ class _BaseFabricModule(CFSNode):
         '''
         Setup fabricmodule with settings from fm dict.
         '''
-        for name, value in fm.iteritems():
+        for name, value in six.iteritems(fm):
             if name != 'name':
                 try:
                     setattr(self, name, value)
@@ -458,5 +459,5 @@ class FabricModule(object):
 
     @classmethod
     def all(cls):
-        for mod in fabric_modules.itervalues():
+        for mod in six.itervalues(fabric_modules):
             yield mod()

--- a/rtslib/node.py
+++ b/rtslib/node.py
@@ -20,7 +20,7 @@ under the License.
 
 import os
 import stat
-from utils import fread, fwrite, RTSLibError, RTSLibNotInCFS
+from .utils import fread, fwrite, RTSLibError, RTSLibNotInCFS
 
 
 class CFSNode(object):

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -23,12 +23,12 @@ import os
 import stat
 import json
 
-from node import CFSNode
-from target import Target
-from fabric import FabricModule
-from tcm import so_mapping, StorageObject
-from utils import RTSLibError, RTSLibBrokenLink, modprobe, mount_configfs
-from utils import dict_remove, set_attributes
+from .node import CFSNode
+from .target import Target
+from .fabric import FabricModule
+from .tcm import so_mapping, StorageObject
+from .utils import RTSLibError, RTSLibBrokenLink, modprobe, mount_configfs
+from .utils import dict_remove, set_attributes
 
 default_save_file = "/etc/target/saveconfig.json"
 

--- a/rtslib/tcm.py
+++ b/rtslib/tcm.py
@@ -23,12 +23,13 @@ import stat
 import re
 import glob
 import resource
+from six.moves import range
 
-from node import CFSNode
-from utils import fread, fwrite, RTSLibError, generate_wwn
-from utils import convert_scsi_path_to_hctl, convert_scsi_hctl_to_path
-from utils import is_dev_in_use, get_blockdev_type
-from utils import get_size_for_blk_dev, get_size_for_disk_name
+from .node import CFSNode
+from .utils import fread, fwrite, RTSLibError, generate_wwn
+from .utils import convert_scsi_path_to_hctl, convert_scsi_hctl_to_path
+from .utils import is_dev_in_use, get_blockdev_type
+from .utils import get_size_for_blk_dev, get_size_for_disk_name
 
 
 class StorageObject(CFSNode):
@@ -185,9 +186,9 @@ class StorageObject(CFSNode):
         listdir = os.listdir
         realpath = os.path.realpath
         path = self.path
-        from root import RTSRoot
-        from target import LUN, TPG, Target
-        from fabric import target_names_excludes
+        from .root import RTSRoot
+        from .target import LUN, TPG, Target
+        from .fabric import target_names_excludes
 
         for base, fm in ((fm.path, fm) for fm in RTSRoot().fabric_modules if fm.exists):
             for tgt_dir in listdir(base):
@@ -899,8 +900,9 @@ class _Backstore(CFSNode):
                                   (self._plugin, name))
             else:
                 # Allocate new index value
-                for index in xrange(1048576):
-                    if index not in bs_cache.values():
+                indexes = set(bs_cache.values())
+                for index in range(1048576):
+                    if index not in indexes:
                         self._index = index
                         bs_cache[self._lookup_key] = self._index
                         break

--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -18,12 +18,13 @@ License for the specific language governing permissions and limitations
 under the License.
 '''
 
-import re
 import os
-import stat
-import uuid
+import re
+import six
 import socket
+import stat
 import subprocess
+import uuid
 from contextlib import contextmanager
 
 class RTSLibError(Exception):
@@ -455,14 +456,14 @@ def _set_auth_attr(self, value, attribute, ignore=False):
             raise
 
 def set_attributes(obj, attr_dict, err_func):
-    for name, value in attr_dict.iteritems():
+    for name, value in six.iteritems(attr_dict):
         try:
             obj.set_attribute(name, value)
         except RTSLibError as e:
             err_func(str(e))
 
 def set_parameters(obj, param_dict, err_func):
-    for name, value in param_dict.iteritems():
+    for name, value in six.iteritems(param_dict):
         try:
             obj.set_parameter(name, value)
         except RTSLibError as e:

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,9 @@ setup (
     url = 'http://github.com/agrover/rtslib-fb',
     packages = ['rtslib_fb', 'rtslib'],
     scripts = ['scripts/targetctl'],
-    use_2to3 = True,
+    "classifiers": [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+    ],
     )


### PR DESCRIPTION
* Replace dict.iteritems() with six.iteritems(dict)
* Replace dict.itervalues() with six.itervalues(dict)
* Fix syntax of relative imports
* Get range from six.moves to get xrange() on Python 2 and range() on
  Python 3
* Replace it.next() with next(it)
* Sort also imports