### PR TITLE
fix a syntax error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup (
     url = 'http://github.com/agrover/rtslib-fb',
     packages = ['rtslib_fb', 'rtslib'],
     scripts = ['scripts/targetctl'],
-    "classifiers": [
+    classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This fixes this error:

```
  File "setup.py", line 31
    "classifiers": [
                 ^
SyntaxError: invalid syntax
```