### PR TITLE
Fix missing import of RTSLibBrokenLink

### DIFF
--- a/rtslib/target.py
+++ b/rtslib/target.py
@@ -25,7 +25,7 @@ from six.moves import range
 import uuid
 
 from .node import CFSNode
-from .utils import RTSLibError
+from .utils import RTSLibBrokenLink, RTSLibError
 from .utils import fread, fwrite, normalize_wwn, generate_wwn
 from .utils import dict_remove, set_attributes, set_parameters, ignored
 from .utils import _get_auth_attr, _set_auth_attr


### PR DESCRIPTION
This patch fixes an import error I introduced in the following commit:

  7f6035f Fix the "unused import" warnings reported by Pylint

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>