### PR TITLE
Use find_parent instead of parent.

### DIFF
--- a/rtslib/utils.py
+++ b/rtslib/utils.py
@@ -231,8 +231,8 @@ def _hctl_from_dev(device):
     @returns: H:C:T:L specifier or None if not found
     @rtype: list of int * 4 or NoneType
     '''
-    parent = device.parent
-    if parent is None or parent.subsystem != 'scsi':
+    parent = device.find_parent(subsystem='scsi')
+    if parent is None:
         return None
 
     try:


### PR DESCRIPTION
Better, because it is sure to find the scsi parent.
You never know what intermediate parent might get interposed.

Better, becaus it does not rely on subsystem property
(which sometimes raises an AttributeError (fixed in pyudev 0.19)).

Signed-off-by: mulhern <amulhern@redhat.com>