### PR TITLE
[rtslib-fb] Ensure internal buffers are flushed when saveconfig.json …

### DIFF
--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -249,7 +249,9 @@ class RTSRoot(CFSNode):
             os.fchmod(f.fileno(), stat.S_IRUSR | stat.S_IWUSR)
             f.write(json.dumps(self.dump(), sort_keys=True, indent=2))
             f.write("\n")
+            f.flush()
             os.fsync(f.fileno())
+            f.close()
 
         os.rename(save_file+".temp", save_file)
 


### PR DESCRIPTION
…is written to disk by save_to_file().  A power-outage, unexpected reboot, etc can lead to zero byte file after a saveconfig.

Signed-off-by: Jon Magrini <jmagrini@redhat.com>