### PR TITLE
Changed example-debian folder for compatibility with dpkg-buildpackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ build/release-stamp:
 			mv $${spectmpl} $$(basename $${spectmpl} .tmpl); \
 		done; \
 		rm -r example-rpm
+	@mv build/${PKGNAME}-${VERSION}/example-debian build/${PKGNAME}-${VERSION}/debian
 	@echo "Generating rpm changelog..."
 	@( \
 		version=$$(basename $$(git describe HEAD --tags | tr - .)); \
@@ -93,7 +94,7 @@ build/release-stamp:
 		echo; \
 		echo " -- $${author}  $${date}"; \
 		echo; \
-	) > build/${PKGNAME}-${VERSION}/example-debian/changelog
+	) > build/${PKGNAME}-${VERSION}/debian/changelog
 	@find build/${PKGNAME}-${VERSION}/ -exec \
 		touch -t $$(date -d @$$(git show -s --format="format:%at") \
 			+"%Y%m%d%H%M.%S") {} \;


### PR DESCRIPTION
To fix #61 added a mv from build/example-debian, to build/debian. Build is now working again on debian.

As it is in build folder, I guess it respects changes made to fix #59.

I'm not used with Makefiles, I don't know if it is the best way to do this !